### PR TITLE
Better Error handling

### DIFF
--- a/array.go
+++ b/array.go
@@ -360,8 +360,11 @@ func copyDenseIter(dst, src DenseTensor, diter, siter Iterator) (int, error) {
 		return copyDense(dst, src), nil
 	}
 
-	if !dst.IsNativelyAccessible() || !src.IsNativelyAccessible() {
-		return 0, errors.Errorf(inaccessibleData, "copy")
+	if !dst.IsNativelyAccessible() {
+		return 0, errors.Errorf(inaccessibleData, dst)
+	}
+	if !src.IsNativelyAccessible() {
+		return 0, errors.Errorf(inaccessibleData, src)
 	}
 
 	if diter == nil {

--- a/defaultengine.go
+++ b/defaultengine.go
@@ -30,7 +30,7 @@ func (e StdEng) Memset(mem Memory, val interface{}) error {
 	if ms, ok := mem.(MemSetter); ok {
 		return ms.Memset(val)
 	}
-	return errors.Errorf("Cannot memset %v with StdEng")
+	return errors.Errorf("Cannot memset %v with StdEng", val)
 }
 
 func (e StdEng) Memclr(mem Memory) {

--- a/defaultengine_argmethods.go
+++ b/defaultengine_argmethods.go
@@ -8,7 +8,7 @@ func (e StdEng) Argmax(t Tensor, axis int) (retVal Tensor, err error) {
 	case DenseTensor:
 		return e.argmaxDenseTensor(tt, axis)
 	default:
-		return nil, errors.Errorf(typeNYI, "StdEng.Argmax", t)
+		return nil, &ErrNotImplemented{errors.Errorf(typeNYI, "StdEng.Argmax", t)}
 	}
 }
 
@@ -95,7 +95,7 @@ func (e StdEng) Argmin(t Tensor, axis int) (retVal Tensor, err error) {
 	case DenseTensor:
 		return e.argminDenseTensor(tt, axis)
 	default:
-		return nil, errors.Errorf(typeNYI, "StdEng.Argmin", t)
+		return nil, &ErrNotImplemented{errors.Errorf(typeNYI, "StdEng.Argmin", t)}
 	}
 }
 

--- a/defaultengine_linalg.go
+++ b/defaultengine_linalg.go
@@ -313,7 +313,7 @@ func (e StdEng) SVD(a Tensor, uv, full bool) (s, u, v Tensor, err error) {
 	var t *Dense
 	var ok bool
 	if err = e.checkAccessible(a); err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "opFail", "SVD")
+		return nil, nil, nil, errors.Wrapf(err, "%v %v", "opFail", "SVD")
 	}
 	if t, ok = a.(*Dense); !ok {
 		return nil, nil, nil, errors.Errorf("StdEng only performs SVDs for DenseTensors. Got %T instead", a)

--- a/defaultengine_linalg.go
+++ b/defaultengine_linalg.go
@@ -445,7 +445,7 @@ func (e StdEng) MatVecMul(a, b, prealloc Tensor) (err error) {
 		alpha, beta := float32(1), float32(0)
 		whichblas.Sgemv(tA, m, n, alpha, A, lda, x, incX, beta, y, incY)
 	default:
-		return errors.Errorf(typeNYI, "matVecMul", bd.Data())
+		return &ErrNotImplemented{errors.Errorf(typeNYI, "matVecMul", bd.Data())}
 	}
 
 	return nil
@@ -539,7 +539,7 @@ func (e StdEng) MatMul(a, b, prealloc Tensor) (err error) {
 			whichblas.Sgemm(tA, tB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
 		}
 	default:
-		return errors.Errorf(typeNYI, "matMul", ad.Data())
+		return &ErrNotImplemented{errors.Errorf(typeNYI, "matMul", ad.Data())}
 	}
 	return
 }
@@ -601,7 +601,7 @@ func (e StdEng) Outer(a, b, prealloc Tensor) (err error) {
 		alpha := float32(1)
 		whichblas.Sger(m, n, alpha, x, incX, y, incY, A, lda)
 	default:
-		return errors.Errorf(typeNYI, "outer", b.Data())
+		return &ErrNotImplemented{errors.Errorf(typeNYI, "outer", b.Data())}
 	}
 	return nil
 }

--- a/defaultengine_mapreduce.go
+++ b/defaultengine_mapreduce.go
@@ -105,7 +105,7 @@ func (e StdEng) Reduce(fn interface{}, a Tensor, axis int, defaultValue interfac
 	case (axis == 0 && at.DataOrder().IsRowMajor()) || ((axis == lastAxis || axis == len(a.Shape())-1) && at.DataOrder().IsColMajor()):
 		var size, split int
 		if at.DataOrder().IsColMajor() {
-			return nil, errors.Errorf("NYI: colmajor")
+			return nil, &ErrNotImplemented{errors.Errorf("NYI: colmajor")}
 		}
 		size = a.Shape()[0]
 		split = a.DataSize() / size
@@ -114,7 +114,7 @@ func (e StdEng) Reduce(fn interface{}, a Tensor, axis int, defaultValue interfac
 	case (axis == lastAxis && at.DataOrder().IsRowMajor()) || (axis == 0 && at.DataOrder().IsColMajor()):
 		var dimSize int
 		if at.DataOrder().IsColMajor() {
-			return nil, errors.Errorf("NYI: colmajor")
+			return nil, &ErrNotImplemented{errors.Errorf("NYI: colmajor")}
 		}
 		dimSize = a.Shape()[axis]
 		err = e.E.ReduceLast(typ, dataA, dataReuse, dimSize, defaultValue, fn)
@@ -150,7 +150,7 @@ func (e StdEng) OptimizedReduce(a Tensor, axis int, firstFn, lastFn, defaultFn, 
 	case (axis == 0 && at.DataOrder().IsRowMajor()) || ((axis == lastAxis || axis == len(a.Shape())-1) && at.DataOrder().IsColMajor()):
 		var size, split int
 		if at.DataOrder().IsColMajor() {
-			return nil, errors.Errorf("NYI: colmajor")
+			return nil, &ErrNotImplemented{errors.Errorf("NYI: colmajor")}
 		}
 		size = a.Shape()[0]
 		split = a.DataSize() / size
@@ -159,7 +159,7 @@ func (e StdEng) OptimizedReduce(a Tensor, axis int, firstFn, lastFn, defaultFn, 
 	case (axis == lastAxis && at.DataOrder().IsRowMajor()) || (axis == 0 && at.DataOrder().IsColMajor()):
 		var dimSize int
 		if at.DataOrder().IsColMajor() {
-			return nil, errors.Errorf("NYI: colmajor")
+			return nil, &ErrNotImplemented{errors.Errorf("NYI: colmajor")}
 		}
 		dimSize = a.Shape()[axis]
 		err = e.E.ReduceLast(typ, dataA, dataReuse, dimSize, defaultValue, lastFn)

--- a/defaultengine_matop_misc.go
+++ b/defaultengine_matop_misc.go
@@ -13,7 +13,7 @@ func (e StdEng) Repeat(t Tensor, axis int, repeats ...int) (Tensor, error) {
 	case DenseTensor:
 		return e.denseRepeat(tt, axis, repeats)
 	default:
-		return nil, errors.Errorf("NYI")
+		return nil, &ErrNotImplemented{errors.Errorf("NYI")}
 	}
 }
 
@@ -81,7 +81,7 @@ func (e StdEng) Concat(t Tensor, axis int, others ...Tensor) (retVal Tensor, err
 		}
 		return e.denseConcat(tt, axis, denses)
 	default:
-		return nil, errors.Errorf("NYI")
+		return nil, &ErrNotImplemented{errors.Errorf("NYI")}
 	}
 }
 
@@ -249,7 +249,7 @@ func (e StdEng) Diag(t Tensor) (retVal Tensor, err error) {
 			bdata[i] = adata[i*stride]
 		}
 	default:
-		return nil, errors.Errorf(typeNYI, "Arbitrary sized diag")
+		return nil, &ErrNotImplemented{errors.Errorf(typeNYI, "Arbitrary sized diag")}
 	}
 	return b, nil
 }

--- a/defaultengine_matop_misc.go
+++ b/defaultengine_matop_misc.go
@@ -249,7 +249,7 @@ func (e StdEng) Diag(t Tensor) (retVal Tensor, err error) {
 			bdata[i] = adata[i*stride]
 		}
 	default:
-		return nil, &ErrNotImplemented{errors.Errorf(typeNYI, "Arbitrary sized diag")}
+		return nil, &ErrNotImplemented{errors.Errorf(typeNYI, "Arbitrary sized diag", t)}
 	}
 	return b, nil
 }

--- a/dense.go
+++ b/dense.go
@@ -129,7 +129,7 @@ func (t *Dense) Engine() Engine { return t.e }
 // Reshape reshapes a *Dense. If the tensors need to be materialized (either it's a view or transpose), it will be materialized before the reshape happens
 func (t *Dense) Reshape(dims ...int) error {
 	if t.viewOf != 0 && t.o.IsNotContiguous() {
-		return errors.Errorf(methodNYI, "Reshape", "non-contiguous views")
+		return &ErrNotImplemented{errors.Errorf(methodNYI, "Reshape", "non-contiguous views")}
 	}
 
 	if !t.old.IsZero() {

--- a/dense_io.go
+++ b/dense_io.go
@@ -643,7 +643,7 @@ func convFromStrs(to Dtype, record []string, into interface{}) (interface{}, err
 		backing = append(backing, record...)
 		return backing, nil
 	default:
-		return nil, errors.Errorf(methodNYI, "convFromStrs", to)
+		return nil, &ErrNotImplemented{errors.Errorf(methodNYI, "convFromStrs", to)}
 	}
 }
 

--- a/dense_matop.go
+++ b/dense_matop.go
@@ -193,7 +193,7 @@ func (t *Dense) CopyTo(other *Dense) error {
 	}
 
 	// TODO: use copyDenseIter
-	return errors.Errorf(methodNYI, "CopyTo", "views")
+	return &ErrNotImplemented{errors.Errorf(methodNYI, "CopyTo", "views")}
 }
 
 // Slice performs slicing on the *Dense Tensor. It returns a view which shares the same underlying memory as the original *Dense.

--- a/errors.go
+++ b/errors.go
@@ -68,7 +68,7 @@ const (
 	unknownState      = "Unknown state reached: Safe %t, Incr %t, Reuse %t"
 	unsupportedDtype  = "Array of %v is unsupported for %v"
 	maskRequired      = "Masked array type required for %v"
-	inaccessibleData  = "Data in %p inaccessble"
+	inaccessibleData  = "Data in %p inaccessible"
 
 	methodNYI = "%q not yet implemented for %v"
 	typeNYI   = "%q not yet implemented for interactions with %T"

--- a/errors.go
+++ b/errors.go
@@ -33,6 +33,15 @@ type errorIndices []int
 func (e errorIndices) Indices() []int { return []int(e) }
 func (e errorIndices) Error() string  { return fmt.Sprintf("Error in indices %v", []int(e)) }
 
+// ErrNotImplemented is triggered when something is not implemented (yet)
+type ErrNotImplemented struct {
+	err error
+}
+
+func (e *ErrNotImplemented) Error() string {
+	return e.err.Error()
+}
+
 const (
 	emptyTensor       = "Tensor is uninitialized (no shape, no data)"
 	dimMismatch       = "Dimension mismatch. Expected %d, got %d"
@@ -59,7 +68,7 @@ const (
 	unknownState      = "Unknown state reached: Safe %t, Incr %t, Reuse %t"
 	unsupportedDtype  = "Array of %v is unsupported for %v"
 	maskRequired      = "Masked array type required for %v"
-	inaccessibleData = "Data in %p inaccessble"
+	inaccessibleData  = "Data in %p inaccessble"
 
 	methodNYI = "%q not yet implemented for %v"
 	typeNYI   = "%q not yet implemented for interactions with %T"

--- a/sparse.go
+++ b/sparse.go
@@ -234,7 +234,7 @@ func (t *CS) T(axes ...int) error {
 	UnsafePermute(axes, []int(t.s))
 	t.o = t.o.toggleColMajor()
 	t.o = MakeDataOrder(t.o, Transposed)
-	return &ErrNotImplemented{errors.Errorf(methodNYI, "T")}
+	return &ErrNotImplemented{errors.Errorf(methodNYI, "T", "CS")}
 }
 
 // UT untransposes the CS
@@ -244,7 +244,7 @@ func (t *CS) UT() { t.T(); t.o = t.o.clearTransposed() }
 func (t *CS) Transpose() error { return nil }
 
 func (t *CS) Apply(fn interface{}, opts ...FuncOpt) (Tensor, error) {
-	return nil, &ErrNotImplemented{errors.Errorf(methodNYI, "Apply")}
+	return nil, &ErrNotImplemented{errors.Errorf(methodNYI, "Apply", "CS")}
 }
 
 func (t *CS) Eq(other interface{}) bool {

--- a/sparse.go
+++ b/sparse.go
@@ -234,7 +234,7 @@ func (t *CS) T(axes ...int) error {
 	UnsafePermute(axes, []int(t.s))
 	t.o = t.o.toggleColMajor()
 	t.o = MakeDataOrder(t.o, Transposed)
-	return errors.Errorf(methodNYI, "T")
+	return &ErrNotImplemented{errors.Errorf(methodNYI, "T")}
 }
 
 // UT untransposes the CS
@@ -244,7 +244,7 @@ func (t *CS) UT() { t.T(); t.o = t.o.clearTransposed() }
 func (t *CS) Transpose() error { return nil }
 
 func (t *CS) Apply(fn interface{}, opts ...FuncOpt) (Tensor, error) {
-	return nil, errors.Errorf(methodNYI, "Apply")
+	return nil, &ErrNotImplemented{errors.Errorf(methodNYI, "Apply")}
 }
 
 func (t *CS) Eq(other interface{}) bool {


### PR DESCRIPTION
In this PR:

* I have introduced a new type `ErrNotImplemented`;
* I have fixed some error messages in order to be able to compile `go test`.

The `ErrNotImplemented` is simply wrapping all the `methodMYI` and `typeNYI` errors. The goal is to be able to cast the error and apply special tests on them (In my `ONNX` test, if the error is a `not yet implemented` I can skip the corresponding test).

_Note_: The tests are compiling but not passing. But on the master branch, as they were not compiling I cannot see if I have introduced any regression.