### PR TITLE
make the tests pass with go > 1.12

### DIFF
--- a/array.go
+++ b/array.go
@@ -360,8 +360,11 @@ func copyDenseIter(dst, src DenseTensor, diter, siter Iterator) (int, error) {
 		return copyDense(dst, src), nil
 	}
 
-	if !dst.IsNativelyAccessible() || !src.IsNativelyAccessible() {
-		return 0, errors.Errorf(inaccessibleData, "copy")
+	if !dst.IsNativelyAccessible() {
+		return 0, errors.Errorf(inaccessibleData, dst)
+	}
+	if !src.IsNativelyAccessible() {
+		return 0, errors.Errorf(inaccessibleData, src)
 	}
 
 	if diter == nil {

--- a/array.go
+++ b/array.go
@@ -224,13 +224,13 @@ func (a *array) swap(i, j int) {
 /* *Array is a Memory */
 
 // Uintptr returns the pointer of the first value of the slab
-func (t *array) Uintptr() uintptr { return uintptr(t.Ptr) }
+func (a *array) Uintptr() uintptr { return uintptr(a.Ptr) }
 
 // MemSize returns how big the slice is in bytes
-func (t *array) MemSize() uintptr { return uintptr(t.L) * t.t.Size() }
+func (a *array) MemSize() uintptr { return uintptr(a.L) * a.t.Size() }
 
 // Pointer returns the pointer of the first value of the slab, as an unsafe.Pointer
-func (t *array) Pointer() unsafe.Pointer { return t.Ptr }
+func (a *array) Pointer() unsafe.Pointer { return a.Ptr }
 
 // Data returns the representation of a slice.
 func (a array) Data() interface{} { return a.v }

--- a/defaultengine.go
+++ b/defaultengine.go
@@ -30,7 +30,7 @@ func (e StdEng) Memset(mem Memory, val interface{}) error {
 	if ms, ok := mem.(MemSetter); ok {
 		return ms.Memset(val)
 	}
-	return errors.Errorf("Cannot memset %v with StdEng")
+	return errors.Errorf("Cannot memset %v with StdEng", mem)
 }
 
 func (e StdEng) Memclr(mem Memory) {

--- a/defaultengine_linalg.go
+++ b/defaultengine_linalg.go
@@ -287,7 +287,6 @@ func (e StdEng) Dot(x, y Tensor, opts ...FuncOpt) (retVal Tensor, err error) {
 	var rd *Dense
 	if rd, err = a.TensorMul(b, axesA, axesB); err != nil {
 		panic(err)
-		return
 	}
 
 	if reuse != nil {
@@ -313,7 +312,7 @@ func (e StdEng) SVD(a Tensor, uv, full bool) (s, u, v Tensor, err error) {
 	var t *Dense
 	var ok bool
 	if err = e.checkAccessible(a); err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "opFail", "SVD")
+		return nil, nil, nil, errors.Wrapf(err, "opFail %v", "SVD")
 	}
 	if t, ok = a.(*Dense); !ok {
 		return nil, nil, nil, errors.Errorf("StdEng only performs SVDs for DenseTensors. Got %T instead", a)

--- a/defaultengine_matop_misc.go
+++ b/defaultengine_matop_misc.go
@@ -249,7 +249,7 @@ func (e StdEng) Diag(t Tensor) (retVal Tensor, err error) {
 			bdata[i] = adata[i*stride]
 		}
 	default:
-		return nil, errors.Errorf(typeNYI, "Arbitrary sized diag")
+		return nil, errors.Errorf(typeNYI, "Arbitrary sized diag", t)
 	}
 	return b, nil
 }

--- a/dense_io_test.go
+++ b/dense_io_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/gob"
 	"os"
 	"os/exec"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,10 +46,12 @@ func TestSaveLoadNumpy(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := "[[ 1.  5.]\n [10. -1.]]\n"
+	expected := `\[\[\s*1\.\s*5\.\]\n \[\s*10\.\s*-1\.\]\]\n`
+	if ok, _ := regexp.Match(expected, buf.Bytes()); !ok {
+		t.Errorf("Did not successfully read numpy file, \n%q\n%q", buf.String(), expected)
+	}
 
 	if buf.String() != expected {
-		t.Errorf("Did not successfully read numpy file, \n%q\n%q", buf.String(), expected)
 	}
 
 	// cleanup

--- a/dense_io_test.go
+++ b/dense_io_test.go
@@ -45,7 +45,7 @@ func TestSaveLoadNumpy(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := "[[  1.   5.]\n [ 10.  -1.]]\n"
+	expected := "[[ 1.  5.]\n [10. -1.]]\n"
 
 	if buf.String() != expected {
 		t.Errorf("Did not successfully read numpy file, \n%q\n%q", buf.String(), expected)

--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ const (
 	unknownState      = "Unknown state reached: Safe %t, Incr %t, Reuse %t"
 	unsupportedDtype  = "Array of %v is unsupported for %v"
 	maskRequired      = "Masked array type required for %v"
-	inaccessibleData = "Data in %p inaccessble"
+	inaccessibleData  = "Data in %p inaccessble"
 
 	methodNYI = "%q not yet implemented for %v"
 	typeNYI   = "%q not yet implemented for interactions with %T"

--- a/sparse.go
+++ b/sparse.go
@@ -234,7 +234,7 @@ func (t *CS) T(axes ...int) error {
 	UnsafePermute(axes, []int(t.s))
 	t.o = t.o.toggleColMajor()
 	t.o = MakeDataOrder(t.o, Transposed)
-	return errors.Errorf(methodNYI, "T")
+	return errors.Errorf(methodNYI, "T", t)
 }
 
 // UT untransposes the CS
@@ -244,7 +244,7 @@ func (t *CS) UT() { t.T(); t.o = t.o.clearTransposed() }
 func (t *CS) Transpose() error { return nil }
 
 func (t *CS) Apply(fn interface{}, opts ...FuncOpt) (Tensor, error) {
-	return nil, errors.Errorf(methodNYI, "Apply")
+	return nil, errors.Errorf(methodNYI, "Apply", t)
 }
 
 func (t *CS) Eq(other interface{}) bool {


### PR DESCRIPTION
This PR contains very little modification on the formatting directive.
The tests were not building on the tip version of Go.

This PR allows the tests to compile; 
The tests are ok, but the examples are falling in a panic because of a problem with the formatting directive.
I have submitted a PR into Go itself that should fix this: https://go-review.googlesource.com/c/go/+/179338
