### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ And here's a visual representation of the `*Dense`.
 
 ![dense](https://github.com/gorgonia/tensor/blob/master/media/dense.png?raw=true)
 
-`*Dense` draws its inspiration from Go's slice. Underlying it all is a flat array, and access to elements are controlled by `*AP`. Where a Go is able to store its metadata in a 3-word stucture (obiviating the need to allocate memory), a `*Dense` unfortunately needs to allocate some memory. The majority of the data is stored in the `*AP` structure, which contains metadata such as shape, stride, and methods for accessing the array.
+`*Dense` draws its inspiration from Go's slice. Underlying it all is a flat array, and access to elements are controlled by `*AP`. Where a Go is able to store its metadata in a 3-word structure (obviating the need to allocate memory), a `*Dense` unfortunately needs to allocate some memory. The majority of the data is stored in the `*AP` structure, which contains metadata such as shape, stride, and methods for accessing the array.
 
 `*Dense` embeds an `array` (not to be confused with Go's array), which is an abstracted data structure that looks like this:
 

--- a/ap.go
+++ b/ap.go
@@ -44,7 +44,7 @@ func MakeAP(shape Shape, strides []int, o DataOrder, Δ Triangle) AP {
 	}
 }
 
-// Init initalizes an already created AP with a shape and stries.
+// Init initializes an already created AP with a shape and stries.
 // It will panic if AP is nil.
 func (ap *AP) Init(shape Shape, strides []int) {
 	ap.shape = shape

--- a/defaultengine_matop_misc.go
+++ b/defaultengine_matop_misc.go
@@ -64,7 +64,7 @@ func (StdEng) denseRepeat(t DenseTensor, axis int, repeats []int) (retVal DenseT
 	var fce fastcopier
 	// we need an engine for fastCopying...
 	e := t.Engine()
-	// e can never be nil. Error would have occured elsewhere
+	// e can never be nil. Error would have occurred elsewhere
 	var ok bool
 	if fce, ok = e.(fastcopier); ok {
 		fastCopy = true

--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@ const (
 	unknownState      = "Unknown state reached: Safe %t, Incr %t, Reuse %t"
 	unsupportedDtype  = "Array of %v is unsupported for %v"
 	maskRequired      = "Masked array type required for %v"
-	inaccessibleData  = "Data in %p inaccessble"
+	inaccessibleData  = "Data in %p inaccessible"
 
 	methodNYI = "%q not yet implemented for %v"
 	typeNYI   = "%q not yet implemented for interactions with %T"


### PR DESCRIPTION
Hello, just fixing some typos.

README.md:
stucture -> structure
obiviating -> obviating

app.go:
initalizes -> initializes

errors.go:
inaccessble -> inaccessible

defaultengine_matop_misc.go:
occured -> occurred