### PR TITLE
Fixed some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It comes to reason then there should be a data structure that handles these thin
 ### Basic Idea: Tensor ###
 A tensor is a multidimensional array. It's like a slice, but works in multiple dimensions.
 
-With slices, there are usage patterns that are repeated enough that warrant abstraction - `append`, `len`, `cap`, `range` are abstrations used to manipulate and query slices. Additionally slicing operations (`a[:1]` for example) are also abstractions provided by the language. Andrew Gerrand wrote a very good write up on [Go's slice usage and internals](https://blog.golang.org/go-slices-usage-and-internals). 
+With slices, there are usage patterns that are repeated enough that warrant abstraction - `append`, `len`, `cap`, `range` are abstractions used to manipulate and query slices. Additionally slicing operations (`a[:1]` for example) are also abstractions provided by the language. Andrew Gerrand wrote a very good write up on [Go's slice usage and internals](https://blog.golang.org/go-slices-usage-and-internals). 
 
 Tensors come with their own set of usage patterns and abstractions. Most of these have analogues in slices, enumerated below (do note that certain slice operation will have more than one tensor analogue - this is due to the number of options available):
 

--- a/example_dense_cmp_test.go
+++ b/example_dense_cmp_test.go
@@ -25,7 +25,7 @@ func ExampleDense_Gt_basic() {
 	T3, _ = V.Gt(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)
@@ -197,7 +197,7 @@ func ExampleDense_Gte_basic() {
 	T3, _ = V.Gte(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)
@@ -369,7 +369,7 @@ func ExampleDense_Lt_basic() {
 	T3, _ = V.Lt(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)
@@ -540,7 +540,7 @@ func ExampleDense_Lte_basic() {
 	T3, _ = V.Lte(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)
@@ -712,7 +712,7 @@ func ExampleDense_ElEq_basic() {
 	T3, _ = V.ElEq(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)
@@ -885,7 +885,7 @@ func ExampleDense_ElNe_basic() {
 	T3, _ = V.ElNe(T2)
 	fmt.Printf("Safe slicing\n============\nT3:\n%v\nT1 remains unchanged:\n%v\n", T3, T1)
 
-	// Simliarly for tensors that return the same type
+	// Similarly for tensors that return the same type
 	T1 = New(WithBacking(Range(Float64, 0, 9)), WithShape(3, 3))
 	sliced, _ = T1.Slice(makeRS(0, 2), makeRS(0, 2))
 	V = sliced.(*Dense)


### PR DESCRIPTION
Just fixing more some typos.

README.md:
abstrations -> abstractions

tensor/example_dense_cmp_test.go:
Simliarly -> Similarly