### PR TITLE
Fix scalar multiplication

### DIFF
--- a/api_arith.go
+++ b/api_arith.go
@@ -150,24 +150,25 @@ func Mul(a, b interface{}, opts ...FuncOpt) (retVal Tensor, err error) {
 				return nil, errors.New("Neither engines of either operand support Mul")
 
 			} else { // one of the operands is a scalar
-				var leftTensor bool
-				if at.Shape().IsScalar() {
-					leftTensor = false // a Scalar-Tensor * b Tensor
-				} else {
-					leftTensor = true // a Tensor * b Scalar-Tensor
+				// Exchange only if the 2nd term is not a scalar
+				if !bt.Shape().IsScalar() {
+					// a Scalar-Tensor * b Tensor
+					tmp := at
+					at = bt
+					bt = tmp
 				}
 
 				if oe != nil {
-					return oe.MulScalar(at, bt, leftTensor, opts...)
+					return oe.MulScalar(at, bt, true, opts...)
 				}
 				if oe = bt.standardEngine(); oe != nil {
-					return oe.MulScalar(at, bt, leftTensor, opts...)
+					return oe.MulScalar(at, bt, true, opts...)
 				}
 				if muler, ok = at.Engine().(Muler); ok {
-					return muler.MulScalar(at, bt, leftTensor, opts...)
+					return muler.MulScalar(at, bt, true, opts...)
 				}
 				if muler, ok = bt.Engine().(Muler); ok {
-					return muler.MulScalar(at, bt, leftTensor, opts...)
+					return muler.MulScalar(at, bt, true, opts...)
 				}
 				return nil, errors.New("Neither engines of either operand support Mul")
 			}

--- a/api_arith_test.go
+++ b/api_arith_test.go
@@ -152,3 +152,59 @@ func TestFMA(t *testing.T) {
 	assert.Equal(t, f.Data(), f2.Data())
 
 }
+
+func TestMulScalarScalar(t *testing.T) {
+	// scalar-scalar
+	a := New(WithBacking([]float64{2}))
+	b := New(WithBacking([]float64{3}))
+	var correct interface{} = 6.0
+
+	res, err := Mul(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// Test commutativity
+	res, err = Mul(b, a)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// scalar-tensor
+	a = New(WithBacking([]float64{3, 2}))
+	b = New(WithBacking([]float64{2}))
+	correct = []float64{6, 4}
+
+	res, err = Mul(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// Test commutativity
+	res, err = Mul(b, a)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// tensor - tensor
+	a = New(WithBacking([]float64{3, 5}))
+	b = New(WithBacking([]float64{7, 2}))
+	correct = []float64{21, 10}
+
+	res, err = Mul(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// Test commutativity
+	res, err = Mul(b, a)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+}


### PR DESCRIPTION
Hello,
I found an issue in the Mul operator, when the 1st term is a scalar, it always returned the 1st term unchanged.
The actual problem seems to be in defaultengine_arith.go, in MulScalar, where the leftTensor parameter is not properly handled (seems that on line 669, it calls Mul in a way that doesn't change the output). However, this is generated code, so I'm not sure how to fix it. Plus, it's actually simpler to commute the 2 terms.
What was the rationale behind the use of leftTensor?

Thanks!