### PR TITLE
Added RepeatReuse API.

### DIFF
--- a/api_matop.go
+++ b/api_matop.go
@@ -13,6 +13,14 @@ func Repeat(t Tensor, axis int, repeats ...int) (retVal Tensor, err error) {
 	return nil, errors.New("Engine does not support Repeat")
 }
 
+// RepeatReuse repeats a Tensor along the axis and the given number of repeats, and puts the results in the provided reuse tensor. If the reuse tensor is not correctly sized, then  an error will be given // ???? , but the results will still be valid.
+func RepeatReuse(t, reuse Tensor, axis int, repeats ...int) (retval Tensor, err error) {
+	if r, ok := t.Engine().(Repeater); ok {
+		return r.RepeatReuse(t, reuse, axis, repeats...)
+	}
+	return nil, errors.New("Engine does not support Repeat")
+}
+
 // T safely transposes a Tensor. It returns a tensor that is not a view of the input tensor - rather, the data is all copied.
 func T(t Tensor, axes ...int) (retVal Tensor, err error) {
 	switch tt := t.(type) {

--- a/dense_svd_test.go
+++ b/dense_svd_test.go
@@ -104,7 +104,7 @@ func testSVD(T, T2, s, u, v *Dense, t string, i int) (err error) {
 	return nil
 }
 
-func Example_DenseSVD() {
+func ExampleDense_SVD() {
 	T := New(
 		WithShape(4, 5),
 		WithBacking([]float64{1, 0, 0, 0, 2, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0}),

--- a/engine.go
+++ b/engine.go
@@ -89,6 +89,7 @@ type DenseStacker interface {
 // Repeater is any engine that can repeat values along the given axis.
 type Repeater interface {
 	Repeat(t Tensor, axis int, repeats ...int) (Tensor, error)
+	RepeatReuse(t Tensor, reuse Tensor, axis int, repeeats ...int) (Tensor, error)
 }
 
 // Diager is any engine that can return a tensor that only contains the diagonal values of the input

--- a/example_dense_matop_test.go
+++ b/example_dense_matop_test.go
@@ -235,3 +235,57 @@ func ExampleRepeatReuse() {
 	// T1 == T2: true
 	// Expected Error: Reuse shape is (1, 4). Expected shape is (3, 4)
 }
+
+func ExampleRepeat_uncommonUses() {
+	T := New(WithBacking([]int{1, 2, 3, 4, 5, 6}), WithShape(2, 3))
+	fmt.Printf("T:\n%v", T)
+
+	fmt.Println("Axis 0 has 2 elements. So we will need to write the number of times each element is to be repeated")
+	fmt.Println("Here, Repeat(T, 0, 3, 2) results in this:")
+	T1, err := Repeat(T, 0, 3, 2)
+	if err != nil {
+		fmt.Printf("Err %v", err)
+	}
+	fmt.Printf("%v", T1)
+	fmt.Println("Observe the 0th element ([1 2 3]) has been repeated 3 times, and the 1st element ([4 5 6]) has been repeated twice")
+	fmt.Println("")
+
+	fmt.Println("We can also repeat on Axis 1. Now along Axis 1 there are 3 elements: ([1 4], [2 5], [3 6])")
+	fmt.Println("So we have to specify how many times to repeat each element.")
+	fmt.Println("Repeat(T, 1, 2, 3, 2) yields the following result:")
+	T1, err = Repeat(T, 1, 2, 3, 2)
+	if err != nil {
+		fmt.Printf("Err %v", err)
+	}
+	fmt.Printf("%v", T1)
+	fmt.Println("Once again, observe that the 1st element ([2 5]) has been repeated 3 times, while the rest have been repeated twice")
+	/*
+	   // TODO break this out to another example
+	   	T1, err = Repeat(T, AllAxes, 2, 3, 2, 2, 2, 2)
+	   	if err != nil {
+	   		fmt.Printf("Err %v", err)
+	   	}
+	   	fmt.Printf("%#v", T1)
+	*/
+
+	// Output:
+	// T:
+	// ⎡1  2  3⎤
+	// ⎣4  5  6⎦
+	// Axis 0 has 2 elements. So we will need to write the number of times each element is to be repeated
+	// Here, Repeat(T, 0, 3, 2) results in this:
+	// ⎡1  2  3⎤
+	// ⎢1  2  3⎥
+	// ⎢1  2  3⎥
+	// ⎢4  5  6⎥
+	// ⎣4  5  6⎦
+	// Observe the 0th element ([1 2 3]) has been repeated 3 times, and the 1st element ([4 5 6]) has been repeated twice
+	//
+	// We can also repeat on Axis 1. Now along Axis 1 there are 3 elements: ([1 4], [2 5], [3 6])
+	// So we have to specify how many times to repeat each element.
+	// Repeat(T, 1, 2, 3, 2) yields the following result:
+	// ⎡1  1  2  2  2  3  3⎤
+	// ⎣4  4  5  5  5  6  6⎦
+	// Once again, observe that the 1st element ([2 5]) has been repeated 3 times, while the rest have been repeated twice
+
+}

--- a/example_dense_matop_test.go
+++ b/example_dense_matop_test.go
@@ -1,6 +1,8 @@
 package tensor
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func ExampleDense_Slice() {
 	var T Tensor
@@ -204,4 +206,32 @@ func ExampleDense_Vstack() {
 	//
 	// Vstacking (4) with (1, 2): Tensor has to be at least 2 dimensions
 	// Vstacking (1, 2) with (4): Tensor has to be at least 2 dimensions
+}
+
+func ExampleRepeatReuse() {
+	var T, T1 *Dense
+	T = New(WithBacking([]float64{1, 2, 3, 4}), WithShape(1, 4))
+	T1 = New(Of(Float64), WithShape(3, 4))
+
+	var T2 Tensor
+	var err error
+	if T2, err = RepeatReuse(T, T1, 0, 3); err != nil {
+		fmt.Printf("Err %v", err)
+	}
+	fmt.Printf("RepeatReuse(T, T1):\n%v", T2)
+	fmt.Printf("T1 == T2: %t\n", T1 == T2)
+
+	// But if your reuse is wrongly shaped, an error occurs
+	T1 = New(Of(Float64), WithShape(1, 4)) // too small
+	if _, err = RepeatReuse(T, T1, 0, 3); err != nil {
+		fmt.Printf("Expected Error: %v\n", err)
+	}
+
+	// Output:
+	// RepeatReuse(T, T1):
+	// ⎡1  2  3  4⎤
+	// ⎢1  2  3  4⎥
+	// ⎣1  2  3  4⎦
+	// T1 == T2: true
+	// Expected Error: Reuse shape is (1, 4). Expected shape is (3, 4)
 }

--- a/example_extension_matop_test.go
+++ b/example_extension_matop_test.go
@@ -24,7 +24,7 @@ func (ss s) Start() int { return int(ss) }
 func (ss s) End() int   { return int(ss) + 1 }
 func (ss s) Step() int  { return 1 }
 
-func ExampleTranspose_Extension() {
+func ExampleTranspose_extension() {
 	// For documentation if you're reading this on godoc:
 	//
 	// type LongStruct struct {

--- a/example_extension_matop_test.go
+++ b/example_extension_matop_test.go
@@ -24,7 +24,7 @@ func (ss s) Start() int { return int(ss) }
 func (ss s) End() int   { return int(ss) + 1 }
 func (ss s) Step() int  { return 1 }
 
-func Example_TransposeExtension() {
+func ExampleTranspose_Extension() {
 	// For documentation if you're reading this on godoc:
 	//
 	// type LongStruct struct {

--- a/example_mapreduce_test.go
+++ b/example_mapreduce_test.go
@@ -2,7 +2,7 @@ package tensor
 
 import "fmt"
 
-func Example_Sum() {
+func ExampleSum() {
 	T := New(WithBacking([]float64{0, 1, 2, 3}), WithShape(2, 2))
 	fmt.Printf("T:\n%v\n", T)
 
@@ -31,7 +31,7 @@ func Example_Sum() {
 	// Summed along (1, 0): 6
 }
 
-func Example_Argmax() {
+func ExampleArgmax() {
 	T := New(WithBacking([]float64{0, 100, 200, 3}), WithShape(2, 2))
 	fmt.Printf("T:\n%v\n", T)
 
@@ -49,7 +49,7 @@ func Example_Argmax() {
 	// Argmax is *tensor.Dense of int
 }
 
-func Example_Argmin() {
+func ExampleArgmin() {
 	T := New(WithBacking([]float64{0, 100, 200, 3}), WithShape(2, 2))
 	fmt.Printf("T:\n%v\n", T)
 

--- a/tensor.go
+++ b/tensor.go
@@ -105,6 +105,9 @@ func assertDense(t Tensor) (*Dense, error) {
 	if retVal, ok := t.(*Dense); ok {
 		return retVal, nil
 	}
+	if retVal, ok := t.(Densor); ok {
+		return retVal.Dense(), nil
+	}
 	return nil, errors.Errorf("%T is not *Dense", t)
 }
 


### PR DESCRIPTION
Right now any engine implementing Repeater is expected to also
implement RepeatReuse. This imposition is strictly unnecessary, but
also makes the number of possible combinations easier to handle for
now.

The reason for adding `RepeatReuse` is due to benchmarks done by
@mattn who has found that the `Repeat` function in Gorgonia causes a
lot of additional allocation. Given that gorgonia.org/gorgonia can
actually determine ahead of time how much space to use, a RepeatReuse
API was designed rapidly to allow taking advantage of that.

We cannot just tack on a `FuncOpt` to `Repeat` as the variadic
parameters are reserved for the number of repeats to be made. Thus a
new function `RepeatReuse` is required. Originally the name was
`RepeatWithReuse` but that is a rather long name.