### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/internal/storage/header.go
+++ b/internal/storage/header.go
@@ -87,12 +87,12 @@ func CopyIter(t reflect.Type, dst, src *Header, diter, siter Iterator) int {
 
 func AsByteSlice(a *Header, t reflect.Type) []byte {
 	size := a.L * int(t.Size())
-	hdr := reflect.SliceHeader{
-		Data: uintptr(a.Ptr),
-		Len:  size,
-		Cap:  size,
-	}
-	return *(*[]byte)(unsafe.Pointer(&hdr))
+	b := make([]byte, 0)
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Data = uintptr(a.Ptr)
+	hdr.Cap = size
+	hdr.Len = size
+	return b
 }
 
 // Element gets the pointer of ith element


### PR DESCRIPTION
I found an incorrect cast `[]byte` in `internal/storage/header.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.