### PR TITLE
Fixed an issue with the leftTensor parameter leading to a bug for scalars

### DIFF
--- a/api_arith_test.go
+++ b/api_arith_test.go
@@ -207,6 +207,24 @@ func TestMulScalarScalar(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 	assert.Equal(t, correct, res.Data())
+
+	// Interface - tensor
+	ai := 2.0
+	b = NewDense(Float64, Shape{1, 1}, WithBacking([]float64{3}))
+	correct = []float64{6.0}
+
+	res, err = Mul(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// Commutativity
+	res, err = Mul(b, ai)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
 }
 
 func TestDivScalarScalar(t *testing.T) {
@@ -249,6 +267,28 @@ func TestDivScalarScalar(t *testing.T) {
 	correct = []float64{3, 5}
 
 	res, err = Div(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// interface-scalar
+	ai := 6.0
+	b = New(WithBacking([]float64{2}))
+	correct = 3.0
+
+	res, err = Div(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// scalar-interface
+	a = New(WithBacking([]float64{6}))
+	bi := 2.0
+	correct = 3.0
+
+	res, err = Div(a, bi)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -309,6 +349,24 @@ func TestAddScalarScalar(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 	assert.Equal(t, correct, res.Data())
+
+	// interface-scalar
+	ai := 2.0
+	b = New(WithBacking([]float64{3}))
+	correct = 5.0
+
+	res, err = Add(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// Test commutativity
+	res, err = Add(b, ai)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
 }
 
 func TestSubScalarScalar(t *testing.T) {
@@ -351,6 +409,28 @@ func TestSubScalarScalar(t *testing.T) {
 	correct = []float64{14, 8}
 
 	res, err = Sub(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// interface-scalar
+	ai := 6.0
+	b = New(WithBacking([]float64{2}))
+	correct = 4.0
+
+	res, err = Sub(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// scalar-interface
+	a = New(WithBacking([]float64{6}))
+	bi := 2.0
+	correct = 4.0
+
+	res, err = Sub(a, bi)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -401,6 +481,28 @@ func TestModScalarScalar(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 	assert.Equal(t, correct, res.Data())
+
+	// interface-scalar
+	ai := 5.0
+	b = New(WithBacking([]float64{2}))
+	correct = 1.0
+
+	res, err = Mod(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// scalar-interface
+	a = New(WithBacking([]float64{5}))
+	bi := 2.0
+	correct = 1.0
+
+	res, err = Mod(a, bi)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
 }
 
 func TestPowScalarScalar(t *testing.T) {
@@ -443,6 +545,28 @@ func TestPowScalarScalar(t *testing.T) {
 	correct = []float64{2187, 100}
 
 	res, err = Pow(a, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// interface-scalar
+	ai := 6.0
+	b = New(WithBacking([]float64{2}))
+	correct = 36.0
+
+	res, err = Pow(ai, b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	assert.Equal(t, correct, res.Data())
+
+	// scalar-interface
+	a = New(WithBacking([]float64{6}))
+	bi := 2.0
+	correct = 36.0
+
+	res, err = Pow(a, bi)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}

--- a/defaultengine_arith.go
+++ b/defaultengine_arith.go
@@ -487,11 +487,10 @@ func (e StdEng) AddScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Add(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Add(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Add(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return
@@ -575,11 +574,10 @@ func (e StdEng) SubScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Sub(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Sub(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Sub(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return
@@ -663,11 +661,10 @@ func (e StdEng) MulScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Mul(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Mul(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Mul(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return
@@ -751,11 +748,10 @@ func (e StdEng) DivScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Div(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Div(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Div(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return
@@ -839,11 +835,10 @@ func (e StdEng) PowScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Pow(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Pow(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Pow(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return
@@ -927,11 +922,10 @@ func (e StdEng) ModScalar(t Tensor, s interface{}, leftTensor bool, opts ...Func
 		retVal = a
 	default:
 		retVal = a.Clone().(Tensor)
-		if leftTensor {
-			err = e.E.Mod(typ, retVal.hdr(), dataB)
-		} else {
-			err = e.E.Mod(typ, dataA, retVal.hdr())
+		if !leftTensor {
+			storage.Fill(typ, retVal.hdr(), dataA)
 		}
+		err = e.E.Mod(typ, retVal.hdr(), dataB)
 	}
 	returnHeader(scalarHeader)
 	return

--- a/genlib2/agg2_body.go
+++ b/genlib2/agg2_body.go
@@ -164,11 +164,10 @@ const agg2BodyRaw = `if useIter {
 			err = e.E.{{.Name}}(typ, retVal.hdr(), dataB)
 		{{else -}}
 			retVal = a.Clone().(Tensor)
-			if leftTensor {
-				err = e.E.{{.Name}}(typ, retVal.hdr(), dataB)
-			} else {
-				err = e.E.{{.Name}}(typ, dataA, retVal.hdr())
+			if !leftTensor {
+				storage.Fill(typ, retVal.hdr(), dataA)
 			}
+			err = e.E.{{.Name}}(typ, retVal.hdr(), dataB)
 		{{end -}}
 	}
 	{{if not .VV -}}returnHeader(scalarHeader){{end}}

--- a/internal/storage/header.go
+++ b/internal/storage/header.go
@@ -56,6 +56,23 @@ func CopySliced(t reflect.Type, dst *Header, dstart, dend int, src *Header, ssta
 	return copied / size
 }
 
+func Fill(t reflect.Type, dst, src *Header) int {
+	dstBA := AsByteSlice(dst, t)
+	srcBA := AsByteSlice(src, t)
+	size := int(t.Size())
+	lenSrc := len(srcBA)
+
+	dstart := 0
+	for {
+		copied := copy(dstBA[dstart:], srcBA)
+		dstart += copied
+		if copied < lenSrc {
+			break
+		}
+	}
+	return dstart / size
+}
+
 func CopyIter(t reflect.Type, dst, src *Header, diter, siter Iterator) int {
 	dstBA := AsByteSlice(dst, t)
 	srcBA := AsByteSlice(src, t)

--- a/internal/storage/header_test.go
+++ b/internal/storage/header_test.go
@@ -1,0 +1,43 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFill(t *testing.T) {
+	// A longer than B
+	a := headerFromSlice([]int{0, 1, 2, 3, 4})
+	b := headerFromSlice([]int{10, 11})
+	copied := Fill(reflect.TypeOf(1), &a, &b)
+
+	assert.Equal(t, copied, 5)
+	assert.Equal(t, a.Ints(), []int{10, 11, 10, 11, 10})
+
+	// B longer than A
+	a = headerFromSlice([]int{10, 11})
+	b = headerFromSlice([]int{0, 1, 2, 3, 4})
+	copied = Fill(reflect.TypeOf(1), &a, &b)
+
+	assert.Equal(t, copied, 2)
+	assert.Equal(t, a.Ints(), []int{0, 1})
+}
+
+func headerFromSlice(x interface{}) Header {
+	xT := reflect.TypeOf(x)
+	if xT.Kind() != reflect.Slice {
+		panic("Expected a slice")
+	}
+
+	xV := reflect.ValueOf(x)
+	uptr := unsafe.Pointer(xV.Pointer())
+
+	return Header{
+		Ptr: uptr,
+		L:   xV.Len(),
+		C:   xV.Cap(),
+	}
+}


### PR DESCRIPTION
Fix for #70 
The issue was that the operation is performed in place on the first operand, but the output is passed as second operand.
The solution was to always use the output as first operand, filling it with the scalar if needed.

I fear that the problem might still exist with iterators.