### PR TITLE
Fix 48 more possible memory confusion bugs

### DIFF
--- a/native/iterator_native.go
+++ b/native/iterator_native.go
@@ -59,12 +59,11 @@ func MatrixB(t *Dense) (retVal [][]bool, err error) {
 	retVal = make([][]bool, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]bool)(unsafe.Pointer(hdr))
+		retVal[i] = make([]bool, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -90,12 +89,11 @@ func Tensor3B(t *Dense) (retVal [][][]bool, err error) {
 		retVal[i] = make([][]bool, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]bool)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]bool, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -129,12 +127,11 @@ func MatrixI(t *Dense) (retVal [][]int, err error) {
 	retVal = make([][]int, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]int)(unsafe.Pointer(hdr))
+		retVal[i] = make([]int, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -160,12 +157,11 @@ func Tensor3I(t *Dense) (retVal [][][]int, err error) {
 		retVal[i] = make([][]int, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]int)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]int, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -199,12 +195,11 @@ func MatrixI8(t *Dense) (retVal [][]int8, err error) {
 	retVal = make([][]int8, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]int8)(unsafe.Pointer(hdr))
+		retVal[i] = make([]int8, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -230,12 +225,11 @@ func Tensor3I8(t *Dense) (retVal [][][]int8, err error) {
 		retVal[i] = make([][]int8, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]int8)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]int8, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -269,12 +263,11 @@ func MatrixI16(t *Dense) (retVal [][]int16, err error) {
 	retVal = make([][]int16, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]int16)(unsafe.Pointer(hdr))
+		retVal[i] = make([]int16, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -300,12 +293,11 @@ func Tensor3I16(t *Dense) (retVal [][][]int16, err error) {
 		retVal[i] = make([][]int16, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]int16)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]int16, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -339,12 +331,11 @@ func MatrixI32(t *Dense) (retVal [][]int32, err error) {
 	retVal = make([][]int32, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]int32)(unsafe.Pointer(hdr))
+		retVal[i] = make([]int32, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -370,12 +361,11 @@ func Tensor3I32(t *Dense) (retVal [][][]int32, err error) {
 		retVal[i] = make([][]int32, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]int32)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]int32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -409,12 +399,11 @@ func MatrixI64(t *Dense) (retVal [][]int64, err error) {
 	retVal = make([][]int64, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]int64)(unsafe.Pointer(hdr))
+		retVal[i] = make([]int64, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -440,12 +429,11 @@ func Tensor3I64(t *Dense) (retVal [][][]int64, err error) {
 		retVal[i] = make([][]int64, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]int64)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]int64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -479,12 +467,11 @@ func MatrixU(t *Dense) (retVal [][]uint, err error) {
 	retVal = make([][]uint, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]uint)(unsafe.Pointer(hdr))
+		retVal[i] = make([]uint, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -510,12 +497,11 @@ func Tensor3U(t *Dense) (retVal [][][]uint, err error) {
 		retVal[i] = make([][]uint, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]uint)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]uint, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -549,12 +535,11 @@ func MatrixU8(t *Dense) (retVal [][]uint8, err error) {
 	retVal = make([][]uint8, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]uint8)(unsafe.Pointer(hdr))
+		retVal[i] = make([]uint8, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -580,12 +565,11 @@ func Tensor3U8(t *Dense) (retVal [][][]uint8, err error) {
 		retVal[i] = make([][]uint8, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]uint8)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]uint8, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -619,12 +603,11 @@ func MatrixU16(t *Dense) (retVal [][]uint16, err error) {
 	retVal = make([][]uint16, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]uint16)(unsafe.Pointer(hdr))
+		retVal[i] = make([]uint16, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -650,12 +633,11 @@ func Tensor3U16(t *Dense) (retVal [][][]uint16, err error) {
 		retVal[i] = make([][]uint16, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]uint16)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]uint16, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -689,12 +671,11 @@ func MatrixU32(t *Dense) (retVal [][]uint32, err error) {
 	retVal = make([][]uint32, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]uint32)(unsafe.Pointer(hdr))
+		retVal[i] = make([]uint32, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -720,12 +701,11 @@ func Tensor3U32(t *Dense) (retVal [][][]uint32, err error) {
 		retVal[i] = make([][]uint32, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]uint32)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]uint32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -759,12 +739,11 @@ func MatrixU64(t *Dense) (retVal [][]uint64, err error) {
 	retVal = make([][]uint64, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]uint64)(unsafe.Pointer(hdr))
+		retVal[i] = make([]uint64, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -790,12 +769,11 @@ func Tensor3U64(t *Dense) (retVal [][][]uint64, err error) {
 		retVal[i] = make([][]uint64, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]uint64)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]uint64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -829,12 +807,11 @@ func MatrixF32(t *Dense) (retVal [][]float32, err error) {
 	retVal = make([][]float32, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]float32)(unsafe.Pointer(hdr))
+		retVal[i] = make([]float32, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -860,12 +837,11 @@ func Tensor3F32(t *Dense) (retVal [][][]float32, err error) {
 		retVal[i] = make([][]float32, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]float32)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]float32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -899,12 +875,11 @@ func MatrixF64(t *Dense) (retVal [][]float64, err error) {
 	retVal = make([][]float64, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]float64)(unsafe.Pointer(hdr))
+		retVal[i] = make([]float64, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -930,12 +905,11 @@ func Tensor3F64(t *Dense) (retVal [][][]float64, err error) {
 		retVal[i] = make([][]float64, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]float64)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]float64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -969,12 +943,11 @@ func MatrixC64(t *Dense) (retVal [][]complex64, err error) {
 	retVal = make([][]complex64, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]complex64)(unsafe.Pointer(hdr))
+		retVal[i] = make([]complex64, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -1000,12 +973,11 @@ func Tensor3C64(t *Dense) (retVal [][][]complex64, err error) {
 		retVal[i] = make([][]complex64, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]complex64)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]complex64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -1039,12 +1011,11 @@ func MatrixC128(t *Dense) (retVal [][]complex128, err error) {
 	retVal = make([][]complex128, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]complex128)(unsafe.Pointer(hdr))
+		retVal[i] = make([]complex128, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -1070,12 +1041,11 @@ func Tensor3C128(t *Dense) (retVal [][][]complex128, err error) {
 		retVal[i] = make([][]complex128, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]complex128)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]complex128, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return
@@ -1109,12 +1079,11 @@ func MatrixStr(t *Dense) (retVal [][]string, err error) {
 	retVal = make([][]string, rows)
 	for i := range retVal {
 		start := i * rowStride
-		hdr := &reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&data[start])),
-			Len:  cols,
-			Cap:  cols,
-		}
-		retVal[i] = *(*[]string)(unsafe.Pointer(hdr))
+		retVal[i] = make([]string, 0)
+		hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i]))
+		hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+		hdr.Cap = cols
+		hdr.Len = cols
 	}
 	return
 }
@@ -1140,12 +1109,11 @@ func Tensor3Str(t *Dense) (retVal [][][]string, err error) {
 		retVal[i] = make([][]string, rows)
 		for j := range retVal[i] {
 			start := i*layerStride + j*rowStride
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[start])),
-				Len:  cols,
-				Cap:  cols,
-			}
-			retVal[i][j] = *(*[]string)(unsafe.Pointer(hdr))
+			retVal[i][j] = make([]string, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&retVal[i][j]))
+			hdr.Data = uintptr(unsafe.Pointer(&data[start]))
+			hdr.Cap = cols
+			hdr.Len = cols
 		}
 	}
 	return

--- a/native/iterator_native2.go
+++ b/native/iterator_native2.go
@@ -50,12 +50,12 @@ func SelectB(t *Dense, axis int) (retVal [][]bool, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]bool, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]bool)(unsafe.Pointer(hdr)))
+			s := make([]bool, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -88,12 +88,12 @@ func SelectI(t *Dense, axis int) (retVal [][]int, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]int, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]int)(unsafe.Pointer(hdr)))
+			s := make([]int, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -126,12 +126,12 @@ func SelectI8(t *Dense, axis int) (retVal [][]int8, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]int8, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]int8)(unsafe.Pointer(hdr)))
+			s := make([]int8, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -164,12 +164,12 @@ func SelectI16(t *Dense, axis int) (retVal [][]int16, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]int16, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]int16)(unsafe.Pointer(hdr)))
+			s := make([]int16, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -202,12 +202,12 @@ func SelectI32(t *Dense, axis int) (retVal [][]int32, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]int32, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]int32)(unsafe.Pointer(hdr)))
+			s := make([]int32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -240,12 +240,12 @@ func SelectI64(t *Dense, axis int) (retVal [][]int64, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]int64, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]int64)(unsafe.Pointer(hdr)))
+			s := make([]int64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -278,12 +278,12 @@ func SelectU(t *Dense, axis int) (retVal [][]uint, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]uint, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]uint)(unsafe.Pointer(hdr)))
+			s := make([]uint, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -316,12 +316,12 @@ func SelectU8(t *Dense, axis int) (retVal [][]uint8, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]uint8, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]uint8)(unsafe.Pointer(hdr)))
+			s := make([]uint8, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -354,12 +354,12 @@ func SelectU16(t *Dense, axis int) (retVal [][]uint16, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]uint16, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]uint16)(unsafe.Pointer(hdr)))
+			s := make([]uint16, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -392,12 +392,12 @@ func SelectU32(t *Dense, axis int) (retVal [][]uint32, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]uint32, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]uint32)(unsafe.Pointer(hdr)))
+			s := make([]uint32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -430,12 +430,12 @@ func SelectU64(t *Dense, axis int) (retVal [][]uint64, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]uint64, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]uint64)(unsafe.Pointer(hdr)))
+			s := make([]uint64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -468,12 +468,12 @@ func SelectF32(t *Dense, axis int) (retVal [][]float32, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]float32, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]float32)(unsafe.Pointer(hdr)))
+			s := make([]float32, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -506,12 +506,12 @@ func SelectF64(t *Dense, axis int) (retVal [][]float64, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]float64, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]float64)(unsafe.Pointer(hdr)))
+			s := make([]float64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -544,12 +544,12 @@ func SelectC64(t *Dense, axis int) (retVal [][]complex64, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]complex64, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]complex64)(unsafe.Pointer(hdr)))
+			s := make([]complex64, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -582,12 +582,12 @@ func SelectC128(t *Dense, axis int) (retVal [][]complex128, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]complex128, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]complex128)(unsafe.Pointer(hdr)))
+			s := make([]complex128, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil
@@ -620,12 +620,12 @@ func SelectStr(t *Dense, axis int) (retVal [][]string, err error) {
 		upper := ProdInts(t.Shape()[:axis+1])
 		retVal = make([][]string, 0, upper)
 		for i, r := 0, 0; r < upper; i += stride {
-			hdr := &reflect.SliceHeader{
-				Data: uintptr(unsafe.Pointer(&data[i])),
-				Len:  stride,
-				Cap:  stride,
-			}
-			retVal = append(retVal, *(*[]string)(unsafe.Pointer(hdr)))
+			s := make([]string, 0)
+			hdr := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+			hdr.Data = uintptr(unsafe.Pointer(&data[i]))
+			hdr.Cap = stride
+			hdr.Len = stride
+			retVal = append(retVal, s)
 			r++
 		}
 		return retVal, nil


### PR DESCRIPTION
I found 48 more incorrect slice constructions in the `native` package and fixed them. These are similar to #68.