### PR TITLE
add conversion form Arrow Tensor to Dense Tensor

### DIFF
--- a/defaultengine_matop_transpose.go
+++ b/defaultengine_matop_transpose.go
@@ -24,6 +24,8 @@ func (e StdEng) denseTranspose(a DenseTensor, expStrides []int) {
 		return
 	}
 
+	e.transposeMask(a)
+
 	switch a.rtype().Size() {
 	case 1:
 		e.denseTranspose1(a, expStrides)
@@ -36,6 +38,23 @@ func (e StdEng) denseTranspose(a DenseTensor, expStrides []int) {
 	default:
 		e.denseTransposeArbitrary(a, expStrides)
 	}
+}
+
+func (e StdEng) transposeMask(a DenseTensor) {
+	if !a.(*Dense).IsMasked() {
+		return
+	}
+
+	orig := a.(*Dense).Mask()
+	tmp := make([]bool, len(orig))
+
+	it := newFlatIterator(a.Info())
+	var j int
+	for i, err := it.Next(); err == nil; i, err = it.Next() {
+		tmp[j] = orig[i]
+		j++
+	}
+	copy(orig, tmp)
 }
 
 func (e StdEng) denseTranspose1(a DenseTensor, expStrides []int) {

--- a/dense_compat.go
+++ b/dense_compat.go
@@ -10,6 +10,7 @@ import (
 
 	arrow "github.com/apache/arrow/go/arrow"
 	arrowArray "github.com/apache/arrow/go/arrow/array"
+	arrowTensor "github.com/apache/arrow/go/arrow/tensor"
 	"github.com/chewxy/math32"
 	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/mat"
@@ -505,6 +506,124 @@ func FromArrowArray(a arrowArray.Interface) *Dense {
 		backing := a.(*arrowArray.Float64).Float64Values()
 		retVal := New(WithBacking(backing, mask), WithShape(r, 1))
 		return retVal
+	default:
+		panic(fmt.Sprintf("Unsupported Arrow DataType - %v", a.DataType()))
+	}
+
+	panic("Unreachable")
+}
+
+// FromArrowTensor converts an "arrow/tensor".Interface into a Tensor of matching DataType.
+func FromArrowTensor(a arrowTensor.Interface) *Dense {
+	a.Retain()
+	defer a.Release()
+
+	var shape []int
+	for _, val := range a.Shape() {
+		shape = append(shape, int(val))
+	}
+
+	switch a.DataType() {
+	case arrow.PrimitiveTypes.Int8:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Int8).Int8Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Int16:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Int16).Int16Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Int32:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Int32).Int32Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Int64:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Int64).Int64Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Uint8:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Uint8).Uint8Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Uint16:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Uint16).Uint16Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Uint32:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Uint32).Uint32Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Uint64:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Uint64).Uint64Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Float32:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Float32).Float32Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	case arrow.PrimitiveTypes.Float64:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.Float64).Float64Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
 	default:
 		panic(fmt.Sprintf("Unsupported Arrow DataType - %v", a.DataType()))
 	}

--- a/dense_compat.go
+++ b/dense_compat.go
@@ -540,70 +540,70 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 	case arrow.PrimitiveTypes.Int8:
 		backing := a.(*arrowTensor.Int8).Int8Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Int16:
 		backing := a.(*arrowTensor.Int16).Int16Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Int32:
 		backing := a.(*arrowTensor.Int32).Int32Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Int64:
 		backing := a.(*arrowTensor.Int64).Int64Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Uint8:
 		backing := a.(*arrowTensor.Uint8).Uint8Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Uint16:
 		backing := a.(*arrowTensor.Uint16).Uint16Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Uint32:
 		backing := a.(*arrowTensor.Uint32).Uint32Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Uint64:
 		backing := a.(*arrowTensor.Uint64).Uint64Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Float32:
 		backing := a.(*arrowTensor.Float32).Float32Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))
 	case arrow.PrimitiveTypes.Float64:
 		backing := a.(*arrowTensor.Float64).Float64Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))

--- a/dense_compat.go
+++ b/dense_compat.go
@@ -523,11 +523,12 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 		shape = append(shape, int(val))
 	}
 
+	if !a.IsContiguous() {
+		panic("Non-contiguous data is Unsupported")
+	}
+
 	switch a.DataType() {
 	case arrow.PrimitiveTypes.Int8:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Int8).Int8Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -535,9 +536,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Int16:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Int16).Int16Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -545,9 +543,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Int32:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Int32).Int32Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -555,9 +550,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Int64:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Int64).Int64Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -565,9 +557,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Uint8:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Uint8).Uint8Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -575,9 +564,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Uint16:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Uint16).Uint16Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -585,9 +571,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Uint32:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Uint32).Uint32Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -595,9 +578,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Uint64:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Uint64).Uint64Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -605,9 +585,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Float32:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Float32).Float32Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))
@@ -615,9 +592,6 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 
 		return New(WithShape(shape...), WithBacking(backing))
 	case arrow.PrimitiveTypes.Float64:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.Float64).Float64Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))

--- a/dense_compat_test.go
+++ b/dense_compat_test.go
@@ -662,16 +662,16 @@ func TestFromArrowTensor(t *testing.T) {
 		colMajorT = FromArrowTensor(colMajor)
 
 		assert.Equal(taat.rowMajorData, rowMajorT.Data(), "test %d: row major %v", i, taat.dt)
-		assert.Equal(len(taat.rowMajorValid), len(rowMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		assert.Equal(len(taat.rowMajorValid), len(rowMajorT.Mask()), "test %d: row major %v mask length incorrect", i, taat.dt)
 		for i, invalid := range rowMajorT.Mask() {
-			assert.Equal(taat.rowMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+			assert.Equal(taat.rowMajorValid[i], !invalid, "test %d: row major %v mask value incorrect", i, taat.dt)
 		}
 		assert.True(colMajorT.Shape().Eq(taat.shape))
 
 		assert.Equal(taat.colMajorData, colMajorT.Data(), "test %d: column major %v", i, taat.dt)
-		assert.Equal(len(taat.colMajorValid), len(colMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		assert.Equal(len(taat.colMajorValid), len(colMajorT.Mask()), "test %d: column major %v mask length incorrect", i, taat.dt)
 		for i, invalid := range colMajorT.Mask() {
-			assert.Equal(taat.colMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+			assert.Equal(taat.colMajorValid[i], !invalid, "test %d: column major %v mask value incorrect", i, taat.dt)
 		}
 		assert.True(rowMajorT.Shape().Eq(taat.shape))
 	}

--- a/dense_compat_test.go
+++ b/dense_compat_test.go
@@ -342,70 +342,92 @@ func TestFromArrowArray(t *testing.T) {
 }
 
 var toArrowTensorTests = []struct {
-	rowMajorData interface{}
-	colMajorData interface{}
-	dt           arrow.DataType
-	shape        Shape
+	rowMajorData  interface{}
+	colMajorData  interface{}
+	rowMajorValid []bool
+	colMajorValid []bool
+	dt            arrow.DataType
+	shape         Shape
 }{
 	{
-		rowMajorData: []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []int8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Int8,
-		shape:        Shape{2, 5},
+		rowMajorData:  []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []int8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Int8,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []int16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Int16,
-		shape:        Shape{2, 5},
+		rowMajorData:  []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []int16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Int16,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []int32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Int32,
-		shape:        Shape{2, 5},
+		rowMajorData:  []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []int32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Int32,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []int64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Int64,
-		shape:        Shape{2, 5},
+		rowMajorData:  []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []int64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Int64,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []uint8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Uint8,
-		shape:        Shape{2, 5},
+		rowMajorData:  []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []uint8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Uint8,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []uint16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Uint16,
-		shape:        Shape{2, 5},
+		rowMajorData:  []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []uint16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Uint16,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []uint32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Uint32,
-		shape:        Shape{2, 5},
+		rowMajorData:  []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []uint32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Uint32,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []uint64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Uint64,
-		shape:        Shape{2, 5},
+		rowMajorData:  []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []uint64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Uint64,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []float32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Float32,
-		shape:        Shape{2, 5},
+		rowMajorData:  []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []float32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Float32,
+		shape:         Shape{2, 5},
 	},
 	{
-		rowMajorData: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-		colMajorData: []float64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
-		dt:           arrow.PrimitiveTypes.Float64,
-		shape:        Shape{2, 5},
+		rowMajorData:  []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData:  []float64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		rowMajorValid: []bool{true, false, true, false, true, false, true, false, true, false},
+		colMajorValid: []bool{true, false, false, true, true, false, false, true, true, false},
+		dt:            arrow.PrimitiveTypes.Float64,
+		shape:         Shape{2, 5},
 	},
 }
 
@@ -427,14 +449,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -448,14 +470,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -469,14 +491,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -490,14 +512,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -511,14 +533,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -532,14 +554,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -553,14 +575,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -574,14 +596,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -595,14 +617,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -616,14 +638,14 @@ func TestFromArrowTensor(t *testing.T) {
 			defer b.Release()
 			b.AppendValues(
 				[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			rowMajorArr = b.NewArray()
 			defer rowMajorArr.Release()
 
 			b.AppendValues(
 				[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-				nil,
+				taat.rowMajorValid,
 			)
 			colMajorArr = b.NewArray()
 			defer colMajorArr.Release()
@@ -640,9 +662,17 @@ func TestFromArrowTensor(t *testing.T) {
 		colMajorT = FromArrowTensor(colMajor)
 
 		assert.Equal(taat.rowMajorData, rowMajorT.Data(), "test %d: row major %v", i, taat.dt)
+		assert.Equal(len(taat.rowMajorValid), len(rowMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		for i, invalid := range rowMajorT.Mask() {
+			assert.Equal(taat.rowMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+		}
 		assert.True(colMajorT.Shape().Eq(taat.shape))
 
 		assert.Equal(taat.colMajorData, colMajorT.Data(), "test %d: column major %v", i, taat.dt)
+		assert.Equal(len(taat.colMajorValid), len(colMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		for i, invalid := range colMajorT.Mask() {
+			assert.Equal(taat.colMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+		}
 		assert.True(rowMajorT.Shape().Eq(taat.shape))
 	}
 }

--- a/dense_compat_test.go
+++ b/dense_compat_test.go
@@ -8,6 +8,7 @@ import (
 	arrow "github.com/apache/arrow/go/arrow"
 	arrowArray "github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/memory"
+	arrowTensor "github.com/apache/arrow/go/arrow/tensor"
 	"github.com/stretchr/testify/assert"
 	"gonum.org/v1/gonum/mat"
 )
@@ -337,5 +338,311 @@ func TestFromArrowArray(t *testing.T) {
 			assert.Equal(taat.valid[i], !invalid)
 		}
 		assert.True(T.Shape().Eq(taat.shape))
+	}
+}
+
+var toArrowTensorTests = []struct {
+	rowMajorData interface{}
+	colMajorData interface{}
+	dt           arrow.DataType
+	shape        Shape
+}{
+	{
+		rowMajorData: []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []int8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Int8,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []int16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Int16,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []int32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Int32,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []int64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Int64,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []uint8{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Uint8,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []uint16{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Uint16,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []uint32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Uint32,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []uint64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Uint64,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []float32{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Float32,
+		shape:        Shape{2, 5},
+	},
+	{
+		rowMajorData: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []float64{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt:           arrow.PrimitiveTypes.Float64,
+		shape:        Shape{2, 5},
+	},
+}
+
+func TestFromArrowTensor(t *testing.T) {
+	assert := assert.New(t)
+	var rowMajorT *Dense
+	var colMajorT *Dense
+	pool := memory.NewGoAllocator()
+
+	for i, taat := range toArrowTensorTests {
+		var rowMajorArr arrowArray.Interface
+		var colMajorArr arrowArray.Interface
+		var rowMajor arrowTensor.Interface
+		var colMajor arrowTensor.Interface
+
+		switch taat.dt {
+		case arrow.PrimitiveTypes.Int8:
+			b := arrowArray.NewInt8Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewInt8(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewInt8(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Int8SizeBytes), int64(arrow.Int8SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Int16:
+			b := arrowArray.NewInt16Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewInt16(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewInt16(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Int16SizeBytes), int64(arrow.Int16SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Int32:
+			b := arrowArray.NewInt32Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewInt32(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewInt32(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Int32SizeBytes), int64(arrow.Int32SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Int64:
+			b := arrowArray.NewInt64Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewInt64(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewInt64(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Int64SizeBytes), int64(arrow.Int64SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Uint8:
+			b := arrowArray.NewUint8Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewUint8(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewUint8(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Uint8SizeBytes), int64(arrow.Uint8SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Uint16:
+			b := arrowArray.NewUint16Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewUint16(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewUint16(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Uint16SizeBytes), int64(arrow.Uint16SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Uint32:
+			b := arrowArray.NewUint32Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewUint32(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewUint32(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Uint32SizeBytes), int64(arrow.Uint32SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Uint64:
+			b := arrowArray.NewUint64Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewUint64(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewUint64(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Uint64SizeBytes), int64(arrow.Uint64SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Float32:
+			b := arrowArray.NewFloat32Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewFloat32(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewFloat32(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Float32SizeBytes), int64(arrow.Float32SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		case arrow.PrimitiveTypes.Float64:
+			b := arrowArray.NewFloat64Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.NewFloat64(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.NewFloat64(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.Float64SizeBytes), int64(arrow.Float64SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		default:
+			t.Errorf("DataType not supported in tests: %v", taat.dt)
+		}
+
+		rowMajorT = FromArrowTensor(rowMajor)
+		colMajorT = FromArrowTensor(colMajor)
+
+		assert.Equal(taat.rowMajorData, rowMajorT.Data(), "test %d: row major %v", i, taat.dt)
+		assert.True(colMajorT.Shape().Eq(taat.shape))
+
+		assert.Equal(taat.colMajorData, colMajorT.Data(), "test %d: column major %v", i, taat.dt)
+		assert.True(rowMajorT.Shape().Eq(taat.shape))
 	}
 }

--- a/genlib2/dense_compat.go
+++ b/genlib2/dense_compat.go
@@ -7,6 +7,7 @@ import (
 
 const importsArrowRaw = `import (
 	arrowArray "github.com/apache/arrow/go/arrow/array"
+	arrowTensor "github.com/apache/arrow/go/arrow/tensor"
 	arrow "github.com/apache/arrow/go/arrow"
 )
 `
@@ -249,7 +250,7 @@ type ArrowData struct {
 	PrimitiveTypes  []string
 }
 
-const compatArrowRaw = `// FromArrowArray converts an "arrow/array".Interface into a Tensor of matching DataType.
+const compatArrowArrayRaw = `// FromArrowArray converts an "arrow/array".Interface into a Tensor of matching DataType.
 func FromArrowArray(a arrowArray.Interface) *Dense {
 	a.Retain()
 	defer a.Release()
@@ -304,18 +305,51 @@ func FromArrowArray(a arrowArray.Interface) *Dense {
 }
 `
 
+const compatArrowTensorRaw = `// FromArrowTensor converts an "arrow/tensor".Interface into a Tensor of matching DataType.
+func FromArrowTensor(a arrowTensor.Interface) *Dense {
+	a.Retain()
+	defer a.Release()
+
+	var shape []int
+	for _, val := range a.Shape() {
+		shape = append(shape, int(val))
+	}
+
+	switch a.DataType() {
+	{{range .PrimitiveTypes -}}
+	case arrow.PrimitiveTypes.{{.}}:
+		if !a.IsContiguous() {
+			panic("Non-contiguous data is Unsupported")
+		}
+		backing := a.(*arrowTensor.{{.}}).{{.}}Values()
+		if a.IsColMajor() {
+			return New(WithShape(shape...), AsFortran(backing))
+		}
+
+		return New(WithShape(shape...), WithBacking(backing))
+	{{end -}}
+	default:
+		panic(fmt.Sprintf("Unsupported Arrow DataType - %v", a.DataType()))
+	}
+
+	panic("Unreachable")
+}
+`
+
 var (
-	importsArrow *template.Template
-	conversions  *template.Template
-	compats      *template.Template
-	compatsArrow *template.Template
+	importsArrow       *template.Template
+	conversions        *template.Template
+	compats            *template.Template
+	compatsArrowArray  *template.Template
+	compatsArrowTensor *template.Template
 )
 
 func init() {
 	importsArrow = template.Must(template.New("imports_arrow").Funcs(funcs).Parse(importsArrowRaw))
 	conversions = template.Must(template.New("conversions").Funcs(funcs).Parse(conversionsRaw))
 	compats = template.Must(template.New("compat").Funcs(funcs).Parse(compatRaw))
-	compatsArrow = template.Must(template.New("compat_arrow").Funcs(funcs).Parse(compatArrowRaw))
+	compatsArrowArray = template.Must(template.New("compat_arrow_array").Funcs(funcs).Parse(compatArrowArrayRaw))
+	compatsArrowTensor = template.Must(template.New("compat_arrow_tensor").Funcs(funcs).Parse(compatArrowTensorRaw))
 }
 
 func generateDenseCompat(f io.Writer, generic Kinds) {
@@ -329,5 +363,6 @@ func generateDenseCompat(f io.Writer, generic Kinds) {
 		FixedWidthTypes: arrowFixedWidthTypes,
 		PrimitiveTypes:  arrowPrimitiveTypes,
 	}
-	compatsArrow.Execute(f, arrowData)
+	compatsArrowArray.Execute(f, arrowData)
+	compatsArrowTensor.Execute(f, arrowData)
 }

--- a/genlib2/dense_compat.go
+++ b/genlib2/dense_compat.go
@@ -315,12 +315,13 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 		shape = append(shape, int(val))
 	}
 
+	if !a.IsContiguous() {
+		panic("Non-contiguous data is Unsupported")
+	}
+
 	switch a.DataType() {
 	{{range .PrimitiveTypes -}}
 	case arrow.PrimitiveTypes.{{.}}:
-		if !a.IsContiguous() {
-			panic("Non-contiguous data is Unsupported")
-		}
 		backing := a.(*arrowTensor.{{.}}).{{.}}Values()
 		if a.IsColMajor() {
 			return New(WithShape(shape...), AsFortran(backing))

--- a/genlib2/dense_compat.go
+++ b/genlib2/dense_compat.go
@@ -333,7 +333,7 @@ func FromArrowTensor(a arrowTensor.Interface) *Dense {
 	case arrow.PrimitiveTypes.{{.}}:
 		backing := a.(*arrowTensor.{{.}}).{{.}}Values()
 		if a.IsColMajor() {
-			return New(WithShape(shape...), WithMask(mask), AsFortran(backing))
+			return New(WithShape(shape...), AsFortran(backing, mask))
 		}
 
 		return New(WithShape(shape...), WithBacking(backing, mask))

--- a/genlib2/dense_compat_tests.go
+++ b/genlib2/dense_compat_tests.go
@@ -244,16 +244,16 @@ func TestFromArrowTensor(t *testing.T){
 		colMajorT = FromArrowTensor(colMajor)
 
 		assert.Equal(taat.rowMajorData, rowMajorT.Data(), "test %d: row major %v", i, taat.dt)
-		assert.Equal(len(taat.rowMajorValid), len(rowMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		assert.Equal(len(taat.rowMajorValid), len(rowMajorT.Mask()), "test %d: row major %v mask length incorrect", i, taat.dt)
 		for i, invalid := range rowMajorT.Mask() {
-			assert.Equal(taat.rowMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+			assert.Equal(taat.rowMajorValid[i], !invalid, "test %d: row major %v mask value incorrect", i, taat.dt)
 		}
 		assert.True(colMajorT.Shape().Eq(taat.shape))
 
 		assert.Equal(taat.colMajorData, colMajorT.Data(), "test %d: column major %v", i, taat.dt)
-		assert.Equal(len(taat.colMajorValid), len(colMajorT.Mask()), "test %d: column major %v", i, taat.dt)
+		assert.Equal(len(taat.colMajorValid), len(colMajorT.Mask()), "test %d: column major %v mask length incorrect", i, taat.dt)
 		for i, invalid := range colMajorT.Mask() {
-			assert.Equal(taat.colMajorValid[i], !invalid, "test %d: column major %v", i, taat.dt)
+			assert.Equal(taat.colMajorValid[i], !invalid, "test %d: column major %v mask value incorrect", i, taat.dt)
 		}
 		assert.True(rowMajorT.Shape().Eq(taat.shape))
 	}

--- a/genlib2/dense_compat_tests.go
+++ b/genlib2/dense_compat_tests.go
@@ -94,7 +94,7 @@ func TestFromMat64(t *testing.T){
 }
 `
 
-const compatArrowTestsRaw = `var toArrowArrayTests = []struct{
+const compatArrowArrayTestsRaw = `var toArrowArrayTests = []struct{
 	data interface{}
 	valid []bool
 	dt arrow.DataType
@@ -181,14 +181,83 @@ func TestFromArrowArray(t *testing.T){
 }
 `
 
+const compatArrowTensorTestsRaw = `var toArrowTensorTests = []struct{
+	rowMajorData interface{}
+	colMajorData interface{}
+	dt arrow.DataType
+	shape Shape
+}{
+	{{range .PrimitiveTypes -}}
+	{
+		rowMajorData: []{{lower .}}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		colMajorData: []{{lower .}}{1, 6, 2, 7, 3, 8, 4, 9, 5, 10},
+		dt: arrow.PrimitiveTypes.{{ . }},
+		shape: Shape{2,5},
+	},
+	{{end -}}
+}
+func TestFromArrowTensor(t *testing.T){
+	assert := assert.New(t)
+	var rowMajorT *Dense
+	var colMajorT *Dense
+	pool := memory.NewGoAllocator()
+
+	for i, taat := range toArrowTensorTests {
+		var rowMajorArr arrowArray.Interface
+		var colMajorArr arrowArray.Interface
+		var rowMajor arrowTensor.Interface
+		var colMajor arrowTensor.Interface
+
+		switch taat.dt {
+		{{range .PrimitiveTypes -}}
+		case arrow.PrimitiveTypes.{{ . }}:
+			b := arrowArray.New{{ . }}Builder(pool)
+			defer b.Release()
+			b.AppendValues(
+				[]{{lower . }}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			rowMajorArr = b.NewArray()
+			defer rowMajorArr.Release()
+
+			b.AppendValues(
+				[]{{lower .}}{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				nil,
+			)
+			colMajorArr = b.NewArray()
+			defer colMajorArr.Release()
+
+			rowMajor = arrowTensor.New{{.}}(rowMajorArr.Data(), []int64{2, 5}, nil, []string{"x", "y"})
+			defer rowMajor.Release()
+			colMajor = arrowTensor.New{{.}}(colMajorArr.Data(), []int64{2, 5}, []int64{int64(arrow.{{ . }}SizeBytes), int64(arrow.{{ . }}SizeBytes * 2)}, []string{"x", "y"})
+			defer colMajor.Release()
+		{{end -}}
+		default:
+			t.Errorf("DataType not supported in tests: %v", taat.dt)
+		}
+
+		rowMajorT = FromArrowTensor(rowMajor)
+		colMajorT = FromArrowTensor(colMajor)
+
+		assert.Equal(taat.rowMajorData, rowMajorT.Data(), "test %d: row major %v", i, taat.dt)
+		assert.True(colMajorT.Shape().Eq(taat.shape))
+
+		assert.Equal(taat.colMajorData, colMajorT.Data(), "test %d: column major %v", i, taat.dt)
+		assert.True(rowMajorT.Shape().Eq(taat.shape))
+	}
+}
+`
+
 var (
-	compatTests      *template.Template
-	compatArrowTests *template.Template
+	compatTests            *template.Template
+	compatArrowArrayTests  *template.Template
+	compatArrowTensorTests *template.Template
 )
 
 func init() {
 	compatTests = template.Must(template.New("testCompat").Funcs(funcs).Parse(compatTestsRaw))
-	compatArrowTests = template.Must(template.New("testArrowCompat").Funcs(funcs).Parse(compatArrowTestsRaw))
+	compatArrowArrayTests = template.Must(template.New("testArrowArrayCompat").Funcs(funcs).Parse(compatArrowArrayTestsRaw))
+	compatArrowTensorTests = template.Must(template.New("testArrowTensorCompat").Funcs(funcs).Parse(compatArrowTensorTestsRaw))
 }
 
 func generateDenseCompatTests(f io.Writer, generic Kinds) {
@@ -201,5 +270,6 @@ func generateDenseCompatTests(f io.Writer, generic Kinds) {
 		FixedWidthTypes: arrowFixedWidthTypes,
 		PrimitiveTypes:  arrowPrimitiveTypes,
 	}
-	compatArrowTests.Execute(f, arrowData)
+	compatArrowArrayTests.Execute(f, arrowData)
+	compatArrowTensorTests.Execute(f, arrowData)
 }


### PR DESCRIPTION
This PR adds the ability to convert an Arrow Tensor to a Dense Tensor.

Notes:

- [x] Add Tests
- [x] Add Basic conversions for `FromArrowTensor` function to Dense Tensor
- [x] Rename some generic Arrow vars in genlib2 to `ArrowArray` to keep consistency with `ArrowTensor` naming
- [x] Update documentation for `WithMask` to include `WithMask` in example
- [x] Allow a mask to be passed to the `AsFortran` ConsOpt
- [x] Add `transposeMask` function for inplace and non-inplace transpose operations
