### PR TITLE
Move unused noopError to test. Simplify handleNoOp function

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -21,7 +21,6 @@ func handleNoOp(err error) error {
 	if err == nil {
 		return nil
 	}
-
 	if _, ok := err.(NoOpError); !ok {
 		return err
 	}

--- a/errors.go
+++ b/errors.go
@@ -21,10 +21,10 @@ func handleNoOp(err error) error {
 	if err == nil {
 		return nil
 	}
-	if _, ok := err.(NoOpError); !ok {
-		return err
+	if _, ok := err.(NoOpError); ok {
+		return nil
 	}
-	return nil
+	return err
 }
 
 type errorIndices []int

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,15 @@
+package tensor
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestHandleNoOp(t *testing.T) {
+	otherErr := errors.New("other error")
+
+	assert.Equal(t, nil, handleNoOp(noopError{}))
+	assert.Equal(t, nil, handleNoOp(nil))
+	assert.Equal(t, otherErr, handleNoOp(otherErr))
+}

--- a/internal/execution/keepsync.go
+++ b/internal/execution/keepsync.go
@@ -23,8 +23,8 @@ func handleNoOp(err error) error {
 	if err == nil {
 		return nil
 	}
-	if _, ok := err.(NoOpError); !ok {
-		return err
+	if _, ok := err.(NoOpError); ok {
+		return nil
 	}
-	return nil
+	return err
 }

--- a/internal/execution/keepsync.go
+++ b/internal/execution/keepsync.go
@@ -19,16 +19,10 @@ type NoOpError interface {
 	NoOp() bool
 }
 
-type noopError struct{}
-
-func (e noopError) NoOp() bool    { return true }
-func (e noopError) Error() string { return "NoOp" }
-
 func handleNoOp(err error) error {
 	if err == nil {
 		return nil
 	}
-
 	if _, ok := err.(NoOpError); !ok {
 		return err
 	}

--- a/internal/execution/keepsync_test.go
+++ b/internal/execution/keepsync_test.go
@@ -1,0 +1,20 @@
+package execution
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type noopError struct{}
+
+func (e noopError) NoOp() bool    { return true }
+func (e noopError) Error() string { return "NoOp" }
+
+func TestHandleNoOp(t *testing.T) {
+	otherErr := errors.New("other error")
+
+	assert.Equal(t, nil, handleNoOp(noopError{}))
+	assert.Equal(t, nil, handleNoOp(nil))
+	assert.Equal(t, otherErr, handleNoOp(otherErr))
+}

--- a/internal/storage/keepsync.go
+++ b/internal/storage/keepsync.go
@@ -20,9 +20,11 @@ type NoOpError interface {
 }
 
 func handleNoOp(err error) error {
+	if err == nil {
+		return nil
+	}
 	if _, ok := err.(NoOpError); ok {
 		return nil
 	}
-
 	return err
 }

--- a/internal/storage/keepsync.go
+++ b/internal/storage/keepsync.go
@@ -19,18 +19,10 @@ type NoOpError interface {
 	NoOp() bool
 }
 
-type noopError struct{}
-
-func (e noopError) NoOp() bool    { return true }
-func (e noopError) Error() string { return "NoOp" }
-
 func handleNoOp(err error) error {
-	if err == nil {
+	if _, ok := err.(NoOpError); ok {
 		return nil
 	}
 
-	if _, ok := err.(NoOpError); !ok {
-		return err
-	}
-	return nil
+	return err
 }

--- a/internal/storage/keepsync_test.go
+++ b/internal/storage/keepsync_test.go
@@ -1,0 +1,20 @@
+package storage
+
+import (
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type noopError struct{}
+
+func (e noopError) NoOp() bool    { return true }
+func (e noopError) Error() string { return "NoOp" }
+
+func TestHandleNoOp(t *testing.T) {
+	otherErr := errors.New("other error")
+
+	assert.Equal(t, nil, handleNoOp(noopError{}))
+	assert.Equal(t, nil, handleNoOp(nil))
+	assert.Equal(t, otherErr, handleNoOp(otherErr))
+}


### PR DESCRIPTION
`noopError` wasn't used so I moved it to the test.

The `nil` check is already handled by the type assertion so I removed it.