### PR TITLE
Fix array.Cap()

### DIFF
--- a/array.go
+++ b/array.go
@@ -47,7 +47,7 @@ func arrayFromSlice(x interface{}) array {
 
 func (a *array) Len() int { return a.Header.TypedLen(a.t.Type) }
 
-func (a *array) Cap() int { return a.Header.TypedLen(a.t.Type) }
+func (a *array) Cap() int { return a.Header.TypedCap(a.t.Type) }
 
 // fromSlice populates the value from a slice
 func (a *array) fromSlice(x interface{}) {
@@ -91,10 +91,8 @@ func (a *array) sliceInto(i, j int, res *array) {
 
 	s := i * int(a.t.Size())
 	e := j * int(a.t.Size())
-	c = c - i
 
 	res.Raw = a.Raw[s:e]
-
 }
 
 // slice slices an array

--- a/internal/storage/header.go
+++ b/internal/storage/header.go
@@ -17,6 +17,10 @@ func (h *Header) TypedLen(t reflect.Type) int {
 	return len(h.Raw) / int(t.Size())
 }
 
+func (h *Header) TypedCap(t reflect.Type) int {
+	return cap(h.Raw) / int(t.Size())
+}
+
 func Copy(t reflect.Type, dst, src *Header) int {
 	copied := copy(dst.Raw, src.Raw)
 	return copied / int(t.Size())


### PR DESCRIPTION
The `array` can be built by calling `arrayFromSlice()`. We cannot be sure that the `cap` of the underlying byte slice is the same as its `len`.