### PR TITLE
Replace deprecated ioutil package

### DIFF
--- a/consopt_test.go
+++ b/consopt_test.go
@@ -4,7 +4,6 @@ package tensor
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -39,7 +38,7 @@ func Test_FromMemory(t *testing.T) {
 		t.Logf("%v", err)
 	}
 
-	f, err := ioutil.TempFile("", "test")
+	f, err := os.CreateTemp("", "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dense_io_test.go
+++ b/dense_io_test.go
@@ -3,7 +3,7 @@ package tensor
 import (
 	"bytes"
 	"encoding/gob"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -75,7 +75,7 @@ func TestSaveLoadNumpy(t *testing.T) {
 	}
 
 	importError := `ImportError: No module named numpy`
-	slurpErr, _ := ioutil.ReadAll(stderr)
+	slurpErr, _ := io.ReadAll(stderr)
 	if ok, _ := regexp.Match(importError, slurpErr); ok {
 		t.Skipf("Skipping numpy test. It would appear that you do not have Numpy installed.")
 	}

--- a/genlib2/main.go
+++ b/genlib2/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -182,7 +181,7 @@ func cleanup(loc string) error {
 		return err
 	}
 	for _, m := range matches {
-		b, err := ioutil.ReadFile(m)
+		b, err := os.ReadFile(m)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`ioutil` has been deprecated in Go 1.16. The same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os).